### PR TITLE
update to handle channel element change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,50 @@
-mustangular
-===========
-An Angular.js application that displays station metrics from the IRIS MUSTANG service on a leaflet map. 
+MUSTANGULAR - by PNSN 2016 - found at github: pnsn/mustangular
 
+installed by Robert Casey, IRIS - Mary 9 2017
 
-General Information:
--------------------
-###Form:
+README INSTRUCTIONS FOR USE
+--------------------------------------------------------------------------------------------------------------------
+** mustangular **
+
+An Angular.js application that displays station metrics from the IRIS MUSTANG service on a leaflet map.
+
+*General Information:*
+
+Form:
+
 The form capitalizes input to the text entry boxes. The metric select is populated from the IRIS MUSTANG metric service. The form cannot be submitted until a date range and a metric is selected.
+Parameters:
 
-###Parameters:
 Accepted URL parameters for changing the map view are:
-   - binmax    = # (float)                : sets maximum binning value,       defaults to 95th percentile
-   - binmin    = # (float)                : sets minimum binning value,       defaults to 5th percentile
-   - bincount  = # (int)                  : sets number of bins,              defaults to 3
-   - view      = max or min or extreme    : sets the value for the station,   defaults to max
-   - coloring  = ascending or descending  : sets the coloring of the icons,   defaults to 'green to red'
 
-###Metric Information:
+    binmax = # (float) : sets maximum binning value, defaults to 95th percentile
+    binmin = # (float) : sets minimum binning value, defaults to 5th percentile
+    bincount = # (int) : sets number of bins, defaults to 3
+    view = max or min or extreme : sets the value for the station, defaults to max
+    coloring = ascending or descending : sets the coloring of the icons, defaults to 'green to red'
+
+Metric Information:
+
 The metric information is from the IRIS MUSTANG metric service.
+Displayed Values:
 
-###Displayed Values:
-Each station can only be respresented by one value. The value is determined by taking the median of the values for each channel and then either the maximum, minimum, or most extreme of the values from the B, H, and E channels. The stations used in determining the value are highlighted on the station's pop-up. The type of value chosen is set by the user. 
+Each station can only be respresented by one value. The value is determined by taking the median of the values for each channel and then either the maximum, minimum, or most extreme of the values from the B, H, and E channels. The stations used in determining the value are highlighted on the station's pop-up. The type of value chosen is set by the user.
+Binning:
 
-###Binning: 
-The coloring of icons is determined by sorting the displayed values into bins. The upper and lower limits of binned values and the number of bins are configured by the user. The bins are even width and inclusive at the lower boundary and exclusive at the upper boundary. Any values that are outside of the limits of the bins are categorized as high or low outliers. 
+The coloring of icons is determined by sorting the displayed values into bins. The upper and lower limits of binned values and the number of bins are configured by the user. The bins are even width and inclusive at the lower boundary and exclusive at the upper boundary. Any values that are outside of the limits of the bins are categorized as high or low outliers.
+Key:
 
-###Key:
-The key has checkboxes for each "bin" that allows users to toggle the corresponding values on the map. The histogram on the key represents the proportion of stations that fall into that bin. 
-
+The key has checkboxes for each "bin" that allows users to toggle the corresponding values on the map. The histogram on the key represents the proportion of stations that fall into that bin.
 Libraries:
-----------
-- Angular.js
-- Angular Material
-- Leaflet.js
-- RainbowVis-JS
-- Angular-leaflet-directive.js
+
+    Angular.js
+    Angular Material
+    Leaflet.js
+    RainbowVis-JS
+    Angular-leaflet-directive.js
 
 Installation:
-------------
+
 Mustangular entirely static and can be served via any frontend web server by cloning the contents of public into the DocumentRoot of your webserver of VirtualHost.
+
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 MUSTANGULAR - by PNSN 2016 - found at github: pnsn/mustangular
 
-installed by Robert Casey, IRIS - Mary 9 2017
+installed by Robert Casey, IRIS - Mar 9, 2017
 
 README INSTRUCTIONS FOR USE
 --------------------------------------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-MUSTANGULAR - by PNSN 2016
+MUSTANGULAR
 ===========
-An Angular.js application that displays station metrics from the IRIS MUSTANG service on a leaflet map.
+An Angular.js application that displays station metrics from the IRIS MUSTANG service on a leaflet map.  (Created by Pacific Northwest Seismic Network - PNSN - 2016)
 
 General Information:
 --------------------

--- a/README.md
+++ b/README.md
@@ -1,14 +1,9 @@
-MUSTANGULAR - by PNSN 2016 - found at github: pnsn/mustangular
-
-installed by Robert Casey, IRIS - Mar 9, 2017
-
-README INSTRUCTIONS FOR USE
---------------------------------------------------------------------------------------------------------------------
-** mustangular **
-
+MUSTANGULAR - by PNSN 2016
+===========
 An Angular.js application that displays station metrics from the IRIS MUSTANG service on a leaflet map.
 
-*General Information:*
+General Information:
+--------------------
 
 Form:
 
@@ -25,17 +20,22 @@ Accepted URL parameters for changing the map view are:
 
 Metric Information:
 
-The metric information is from the IRIS MUSTANG metric service.
+The metric information is from the IRIS MUSTANG metric service.  ( https://service.iris.edu/mustang/metrics/1 )
+
 Displayed Values:
 
 Each station can only be respresented by one value. The value is determined by taking the median of the values for each channel and then either the maximum, minimum, or most extreme of the values from the B, H, and E channels. The stations used in determining the value are highlighted on the station's pop-up. The type of value chosen is set by the user.
+
 Binning:
 
 The coloring of icons is determined by sorting the displayed values into bins. The upper and lower limits of binned values and the number of bins are configured by the user. The bins are even width and inclusive at the lower boundary and exclusive at the upper boundary. Any values that are outside of the limits of the bins are categorized as high or low outliers.
+
 Key:
 
 The key has checkboxes for each "bin" that allows users to toggle the corresponding values on the map. The histogram on the key represents the proportion of stations that fall into that bin.
+
 Libraries:
+----------
 
     Angular.js
     Angular Material
@@ -44,7 +44,8 @@ Libraries:
     Angular-leaflet-directive.js
 
 Installation:
+-------------
 
-Mustangular entirely static and can be served via any frontend web server by cloning the contents of public into the DocumentRoot of your webserver of VirtualHost.
+Mustangular is entirely static and can be served via any frontend web server by cloning the contents of public into the DocumentRoot of your webserver of VirtualHost.
 
 

--- a/public/css/mustangular.css
+++ b/public/css/mustangular.css
@@ -36,6 +36,7 @@ html, body {
 
 h1.md-display-2{
   margin: 10px 0px;
+  background-color: #66ccff
 }
 
 .leaflet-popup ul{

--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,11 @@
 
 <md-content layout-padding flex-gt-sm="50" flex-sm="75" class="md-whiteframe-6dp">
    <h1 class="md-display-2">
-      <md-icon md-svg-icon="images/mustangular_logo.svg" aria-label="mustangular"></md-icon>Mustangular V1</h1>
+      <md-icon md-svg-icon="images/mustangular_logo.svg" aria-label="mustangular"></md-icon>
+	MUSTANGular v1.0</h1>
+   <h3 align=right>An Angular.js application that displays station metrics from the IRIS MUSTANG service on a leaflet map.<br>
+		<a href="https://github.com/pnsn/mustangular#mustangular">More info...</a></h3>
+   <h3 align=left>Enter your query below:</h3>
    <form name="mainForm" ng-submit="mainForm.$valid && submit(params)" autocomplete="on">
       <md-input-container class="md-block" >
          <label> Network </label>
@@ -52,8 +56,7 @@
             <md-option ng-repeat="x in metrics" value="{{x.metric}}">{{x.title}}</md-option>
          </md-select>
       </md-input-container>  
-      <md-button type="submit" class="md-raised md-primary">Submit</md-button>
-      <p>Unspecified values will act as wildcards.</p>
+      <md-button type="submit" class="md-raised md-primary">Get Metrics</md-button>&nbsp;&nbsp;Note: Unspecified values will act as wildcards.
    </form>
 </md-content>
 

--- a/public/javascripts/mustangular_map.js
+++ b/public/javascripts/mustangular_map.js
@@ -5,9 +5,6 @@ var mapApp = angular.module('mapApp', ['leaflet-directive', 'ngSanitize', 'ngMes
 mapApp.service('DataFinder', ["$http", "$q", function($http, $q){
   var _metricName = "";
 
-// REC
-	console.log("DEBUG 3");
-  
   // Returns promise with MUSTANG data or error information
   this.getMetricData = function(query){
     var deferred = $q.defer();
@@ -168,9 +165,6 @@ mapApp.service('DataProcessor', ["$filter", function($filter){
         metric.lng = sta.longitude;
         metric.elev = sta.elevation;
 
-	// REC
-	console.log("DEBUG: metric.cha = " + metric.cha);
-
         if(_combinedData[key]){
           if(_combinedData[key].chans[metric.cha]){
             _combinedData[key].chans[metric.cha].push(metric.value); //need the median value
@@ -207,18 +201,12 @@ mapApp.service('DataProcessor', ["$filter", function($filter){
       var minValue = Number.MAX_SAFE_INTEGER;
       var extremeValue = 0;
 
-	// REC
-	console.log("DEBUG: station.chans length = " + station.chans.length);
-
       angular.forEach(station.chans, function(channel, key){
         var orderedChans = $filter('orderBy')(channel); 
         
         //Find the middle index value
         var mid = orderedChans.length/2-.5;
 
-	// REC
-	console.log("DEBUG: channel = " + channel);
-        
         //Default to 0
         var median = 0;
         
@@ -619,8 +607,6 @@ mapApp.controller("MapCtrl", ["$scope", "$window", "$mdDialog", "DataFinder", "D
     $scope.status.inProgress = response.inProgress;
   };
 
-  console.log("DEBUG 2");
-
   // Gets station metrics from MUSTANG
   DataFinder.getMetricData("http://service.iris.edu/mustang/measurements/1/query"+ params +"&nodata=404&output=jsonp&callback=JSON_CALLBACK")
     // If it successfully gets the data
@@ -639,10 +625,6 @@ mapApp.controller("MapCtrl", ["$scope", "$window", "$mdDialog", "DataFinder", "D
         .then(function(stationData){
           $scope.status.hasData = stationData.hasData;
 
-	  // REC
-          console.log("DEBUG 1");
-	  console.log("hasData = " + stationData.hasData);
-          
           // Merge the station metrics and the station coordinates into one
           // Includes calculation of median for each station
           var stations = DataProcessor.getStations(stationData.data, metricData.data);

--- a/public/javascripts/mustangular_map.js
+++ b/public/javascripts/mustangular_map.js
@@ -4,6 +4,9 @@ var mapApp = angular.module('mapApp', ['leaflet-directive', 'ngSanitize', 'ngMes
 // Gets the list of metrics from mustang/metrics for metric dropdown
 mapApp.service('DataFinder', ["$http", "$q", function($http, $q){
   var _metricName = "";
+
+// REC
+	console.log("DEBUG 3");
   
   // Returns promise with MUSTANG data or error information
   this.getMetricData = function(query){
@@ -118,7 +121,7 @@ mapApp.service('DataProcessor', ["$filter", function($filter){
   // Returns the combined datasets as one object
   this.getStations = function(stationData, metricData){
     stationProcessor(stationData);
-    metricProcessor(metricData);
+    metricProcessor(metricData);  // produces _combinedData
     return medianFinder(_combinedData);
   };
   
@@ -153,6 +156,8 @@ mapApp.service('DataProcessor', ["$filter", function($filter){
   // Combines the multiple values for each station and channel into one station object
   // that has multiple channels with multple values for each channel
   // Adds latitude and longitude to each object
+  // REC - JSON output change from 'chan' to 'cha' caused problems here until metric.chan
+  // was changed to metric.cha -- Nov 13, 2017
   var metricProcessor = function(data){
     for(var i = 0; i < data.length; i++){
       var key = data[i].net+"_"+data[i].sta;
@@ -163,11 +168,14 @@ mapApp.service('DataProcessor', ["$filter", function($filter){
         metric.lng = sta.longitude;
         metric.elev = sta.elevation;
 
+	// REC
+	console.log("DEBUG: metric.cha = " + metric.cha);
+
         if(_combinedData[key]){
-          if(_combinedData[key].chans[metric.chan]){
-            _combinedData[key].chans[metric.chan].push(metric.value); //need the median value
+          if(_combinedData[key].chans[metric.cha]){
+            _combinedData[key].chans[metric.cha].push(metric.value); //need the median value
           } else {
-            _combinedData[key].chans[metric.chan] = [metric.value];
+            _combinedData[key].chans[metric.cha] = [metric.value];
           }
         } else{
           _combinedData[key] = { 
@@ -179,7 +187,7 @@ mapApp.service('DataProcessor', ["$filter", function($filter){
           };
           
           _latlngs.push([parseFloat(metric.lat), parseFloat(metric.lng)]);
-          _combinedData[key].chans[metric.chan] = [metric.value];
+          _combinedData[key].chans[metric.cha] = [metric.value];
         }
       } else {
         //put it in a table
@@ -198,11 +206,18 @@ mapApp.service('DataProcessor', ["$filter", function($filter){
       var maxValue = Number.MIN_SAFE_INTEGER;
       var minValue = Number.MAX_SAFE_INTEGER;
       var extremeValue = 0;
+
+	// REC
+	console.log("DEBUG: station.chans length = " + station.chans.length);
+
       angular.forEach(station.chans, function(channel, key){
         var orderedChans = $filter('orderBy')(channel); 
         
         //Find the middle index value
         var mid = orderedChans.length/2-.5;
+
+	// REC
+	console.log("DEBUG: channel = " + channel);
         
         //Default to 0
         var median = 0;
@@ -603,24 +618,30 @@ mapApp.controller("MapCtrl", ["$scope", "$window", "$mdDialog", "DataFinder", "D
     $scope.status.message = response.message;
     $scope.status.inProgress = response.inProgress;
   };
-  
+
+  console.log("DEBUG 2");
+
   // Gets station metrics from MUSTANG
-  DataFinder.getMetricData("http://service.iris.edu/mustang/measurements/1/query"+ params +"&nodata=200&output=jsonp&callback=JSON_CALLBACK")
+  DataFinder.getMetricData("http://service.iris.edu/mustang/measurements/1/query"+ params +"&nodata=404&output=jsonp&callback=JSON_CALLBACK")
     // If it successfully gets the data
     .then(function(metricData){
       $scope.status.message = metricData.message;
       $scope.status.inProgress = metricData.inProgress ? metricData.inProgress : $scope.status.inProgress;    
       
       // Gets the information about the metric from MUSTANG
-      DataFinder.getMetricInfo("http://service.iris.edu/mustang/metrics/1/query?output=jsonp&nodata=200&callback=JSON_CALLBACK&metric=").then(function(metricInfo){
+      DataFinder.getMetricInfo("http://service.iris.edu/mustang/metrics/1/query?output=jsonp&nodata=404&callback=JSON_CALLBACK&metric=").then(function(metricInfo){
         $scope.metricInfo = metricInfo;
       });
     
       // Gets the coordinates of the stations from IRIS FDSNWS
-      DataFinder.getStationData("http://service.iris.edu/fdsnws/station/1/query"+params+"&format=text")
+      DataFinder.getStationData("http://service.iris.edu/fdsnws/station/1/query"+params+"&format=text&nodata=404")
         //If it successfully gets the data
         .then(function(stationData){
           $scope.status.hasData = stationData.hasData;
+
+	  // REC
+          console.log("DEBUG 1");
+	  console.log("hasData = " + stationData.hasData);
           
           // Merge the station metrics and the station coordinates into one
           // Includes calculation of median for each station
@@ -724,6 +745,7 @@ function DialogController($scope, $mdDialog) {
 
 // Disables default debugging output on angular leaflet
 mapApp.config(['$logProvider', '$locationProvider',function($logProvider, $locationProvider){
+// REC
   $logProvider.debugEnabled(false);
   
   $locationProvider.html5Mode({


### PR DESCRIPTION
MUSTANG had some inconsistent representation of the channel term:  sometimes 'cha', sometimes 'chan', so the latest major update regularized output to 'cha' in all instances.  This inadvertently caused an element naming problem for XML and JSON(P) output parsing, so this patch introduces a fix.  In addition, some console logging has been left in place, though it can be removed in a further cleanup pass.